### PR TITLE
fix: set the class to default export in hkp.d.ts

### DIFF
--- a/src/hkp.d.ts
+++ b/src/hkp.d.ts
@@ -1,4 +1,4 @@
-export class HKP {
+export default class HKP {
   constructor(keyServerBaseUrl?: string);
   public lookup(options: { keyid?: string, query?: string }): Promise<string | undefined>;
 }


### PR DESCRIPTION
Currently this doesn't match the actual export and TS in an ES Module will make you `import { HKP } from "@openpgp/hkp-client"`, which will throw an error at runtime.